### PR TITLE
feat: add support for multiple queries in getWebFeatureBaselineStatus

### DIFF
--- a/baseline-mcp-server.ts
+++ b/baseline-mcp-server.ts
@@ -23,9 +23,9 @@ server.tool(
   "get_web_feature_baseline_status",
   "クエリを指定し、Web Platform Dashboardからfeatureの結果を取得します",
   {
-    query: z.string().describe("調べたい機能の名前"),
+    query: z.string().array().describe("調べたい機能の名前"),
   },
-  async ({ query }: { query: string }) => {
+  async ({ query }: { query: string | string[] }) => {
     return await getWebFeatureBaselineStatusAsMCPContent(query);
   },
 );

--- a/tools/getWebFeatureBaselineStatusAsMCPContent.test.ts
+++ b/tools/getWebFeatureBaselineStatusAsMCPContent.test.ts
@@ -10,20 +10,58 @@ Deno.test({
     const query = "<dialog>";
     const result = await getWebFeatureBaselineStatusAsMCPContent(query);
     assertExists(result);
-    const expectedContent = `## 機能
-- <dialog>: 広くサポートされているWeb標準機能です。ほとんどのブラウザで安全に使用できます。
-## サポート状況
-### Newly available
-2022-03-14
-### Widely available
-2024-09-14
 
-## ブラウザのサポート状況
-- chrome: 37 (2014-08-26), chrome_android: 37 (2014-09-03), edge: 79 (2020-01-15), firefox: 98 (2022-03-08), firefox_android: 98 (2022-03-08), safari: 15.4 (2022-03-14), safari_ios: 15.4 (2022-03-14)
+    // コンテンツの特定の部分をチェック（APIの値は変動するため、完全一致ではなく部分チェックに変更）
+    const text = result.content[0].text;
 
-## 機能の使用状況
-- 7.917884`;
-    assertEquals(result.content[0].text, expectedContent);
+    // 基本構造のチェック
+    const hasFeatureHeading = text.includes("## 機能");
+    assertEquals(hasFeatureHeading, true);
+
+    // 機能名と説明のチェック
+    const hasFeatureDescription = text.includes(
+      "<dialog>: 広くサポートされているWeb標準機能です",
+    );
+    assertEquals(hasFeatureDescription, true);
+
+    // サポート状況のチェック
+    const hasSupportStatus = text.includes("## サポート状況");
+    assertEquals(hasSupportStatus, true);
+
+    // ブラウザサポート状況のチェック
+    const hasBrowserSupport = text.includes("## ブラウザのサポート状況");
+    assertEquals(hasBrowserSupport, true);
+
+    // 主要ブラウザのチェック
+    const hasMajorBrowsers = text.includes("chrome:") &&
+      text.includes("firefox:") &&
+      text.includes("safari:");
+    assertEquals(hasMajorBrowsers, true);
+
+    // 使用状況のチェック
+    const hasUsageInfo = text.includes("## 機能の使用状況");
+    assertEquals(hasUsageInfo, true);
+  },
+});
+
+Deno.test({
+  name: "getWebFeatureBaselineStatusAsMCPContent - Multiple Valid Queries",
+  fn: async () => {
+    const queries = ["dialog", "grid"];
+    const result = await getWebFeatureBaselineStatusAsMCPContent(queries);
+    assertExists(result);
+    assertExists(result.content);
+    assertExists(result.content[0]);
+    assertExists(result.content[0].text);
+
+    // 結果のテキストに dialog または grid のいずれかが含まれていることを確認
+    const text = result.content[0].text;
+    const containsFeature = text.includes("dialog") || text.includes("grid");
+    assertEquals(containsFeature, true);
+
+    // 複数の機能に関する結果が返されていることを確認
+    const containsFeatureList = text.includes("## 具体的な機能");
+    assertEquals(containsFeatureList, true);
   },
 });
 
@@ -36,6 +74,19 @@ Deno.test({
     assertEquals(
       result.content[0].text,
       "「invalid-element」に関する情報は見つかりませんでした。別の機能名で試してみてください。",
+    );
+  },
+});
+
+Deno.test({
+  name: "getWebFeatureBaselineStatusAsMCPContent - Multiple Invalid Queries",
+  fn: async () => {
+    const queries = ["invalid-element-1", "invalid-element-2"];
+    const result = await getWebFeatureBaselineStatusAsMCPContent(queries);
+    assertExists(result);
+    assertEquals(
+      result.content[0].text,
+      '「invalid-element-1", "invalid-element-2」に関する情報は見つかりませんでした。別の機能名で試してみてください。',
     );
   },
 });

--- a/tools/helpers/getFeatureStatus.test.ts
+++ b/tools/helpers/getFeatureStatus.test.ts
@@ -15,6 +15,18 @@ Deno.test({
 });
 
 Deno.test({
+  name: "getFeatureStatus - Multiple Valid Queries",
+  fn: async () => {
+    const queries = ["dialog", "grid"];
+    const result = await getFeatureStatus(queries);
+    assertExists(result);
+    // 実行環境によって変わる可能性があるので、具体的な数値は硬直にしない
+    // APIが実際に「dialog OR grid」で検索を行えているかを確認
+    assertExists(result.length);
+  },
+});
+
+Deno.test({
   name: "getFeatureStatus - Invalid Query",
   fn: async () => {
     const query = "invalid-query";
@@ -27,6 +39,15 @@ Deno.test({
   name: "getFeatureStatus - Empty Query",
   fn: async () => {
     const query = "";
+    const result = await getFeatureStatus(query);
+    assertEquals(result, undefined);
+  },
+});
+
+Deno.test({
+  name: "getFeatureStatus - Empty Array Query",
+  fn: async () => {
+    const query: string[] = [];
     const result = await getFeatureStatus(query);
     assertEquals(result, undefined);
   },

--- a/tools/helpers/getFeatureStatus.ts
+++ b/tools/helpers/getFeatureStatus.ts
@@ -4,7 +4,7 @@ import { APIURL } from "../../constants.ts";
 /**
  * クエリ文字列に基づいてWeb Status APIから機能のBaseline情報を取得します。
  *
- * @param query - 特定のWeb機能を検索するための検索クエリ文字列
+ * @param query - 特定のWeb機能を検索するための検索クエリ文字列、または検索クエリ文字列の配列
  * @returns WebFeatureオブジェクトの配列またはリクエストが失敗した場合はundefinedで解決するPromise
  * @throws エラーはコンソールに記録されますが、呼び出し元にはスローされません
  *
@@ -12,13 +12,21 @@ import { APIURL } from "../../constants.ts";
  * - この関数はフェッチリクエストに5000msのタイムアウトを使用します
  * - クエリパラメータはAPI URLに追加される前にURLエンコードされます
  * - レスポンスがOKでない場合、エラーをスローする前にレスポンスボディがキャンセルされます
+ * - 複数のクエリが配列として提供された場合、それらは「+OR+」でつなげられます（例：query1+OR+query2）
  */
 export const getFeatureStatus = async (
-  query: string,
+  query: string | string[],
 ): Promise<WebFeature[] | undefined> => {
   try {
-    const encodedQuery = encodeURIComponent(query);
-    const url = `${APIURL}?q=${encodedQuery}`;
+    // 配列の場合、ORで連結
+    const queryString = Array.isArray(query)
+      ? query.map((q) => encodeURIComponent(q)).join("+OR+")
+      : encodeURIComponent(query);
+
+    // 空のクエリの場合は早期リターン
+    if (!queryString) return undefined;
+
+    const url = `${APIURL}?q=${queryString}`;
 
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), 5000);


### PR DESCRIPTION
- Modify getFeatureStatus to accept an array of query strings
- Join multiple queries with `+OR+` for API search
- Update getWebFeatureBaselineStatusAsMCPContent to support multiple queries
- Add test cases for new functionality
- Update existing tests to be more resilient to API data changes