### PR TITLE
Fix baseline category deduplication

### DIFF
--- a/tools/getWebFeatureBaselineStatusAsMCPContent.test.ts
+++ b/tools/getWebFeatureBaselineStatusAsMCPContent.test.ts
@@ -92,7 +92,8 @@ Deno.test({
 });
 
 Deno.test({
-  name: "getWebFeatureBaselineStatusAsMCPContent - Deduplicates baseline statuses",
+  name:
+    "getWebFeatureBaselineStatusAsMCPContent - Deduplicates baseline statuses",
   fn: async () => {
     const query = "grid";
     const result = await getWebFeatureBaselineStatusAsMCPContent(query);

--- a/tools/getWebFeatureBaselineStatusAsMCPContent.test.ts
+++ b/tools/getWebFeatureBaselineStatusAsMCPContent.test.ts
@@ -90,3 +90,16 @@ Deno.test({
     );
   },
 });
+
+Deno.test({
+  name: "getWebFeatureBaselineStatusAsMCPContent - Deduplicates baseline statuses",
+  fn: async () => {
+    const query = "grid";
+    const result = await getWebFeatureBaselineStatusAsMCPContent(query);
+    assertExists(result);
+    const text = result.content[0].text;
+    const widelyCount = (text.match(/### Widely available/g) || []).length;
+    // API から複数の Grid 関連機能が返るが、Widely カテゴリは 1 度だけ表示される
+    assertEquals(widelyCount, 1);
+  },
+});

--- a/tools/getWebFeatureBaselineStatusAsMCPContent.ts
+++ b/tools/getWebFeatureBaselineStatusAsMCPContent.ts
@@ -38,9 +38,20 @@ export const getWebFeatureBaselineStatusAsMCPContent = async (
     }
 
     // Baselineカテゴリのリストを作成
-    const baselineCategories = webFeatures
-      .map((feature) => feature.baseline)
-      .filter((value, index, self) => self.indexOf(value) === index);
+    // Web Status API では基本的に重複しないが、防御的に status 単位で
+    // 重複を排除して最初に出現したデータだけを保持する
+    const seenStatuses = new Set<BaselineStatus>();
+    const baselineCategories = webFeatures.reduce<{
+      status: BaselineStatus;
+      high_date?: string;
+      low_date?: string;
+    }[]>((acc, feature) => {
+      if (!seenStatuses.has(feature.baseline.status)) {
+        seenStatuses.add(feature.baseline.status);
+        acc.push(feature.baseline);
+      }
+      return acc;
+    }, []);
 
     // BrowserImplementationsDataを取得
     const browserImplementationsData = webFeatures.map(


### PR DESCRIPTION
## Summary
- defensively dedupe baseline categories by status
- test that output only includes unique baseline statuses

## Testing
- `deno task test` *(fails: `deno: command not found`)*