### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,3 +121,8 @@ Sonnetによって実装、ドキュメントのサンプルを提案いただ�
 ## ライセンス
 
 [MIT License](./LICENSE)
+
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/yamanoku-baseline-mcp-server).
+


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/yamanoku-baseline-mcp-server).